### PR TITLE
Bugfix for DAQ channel import

### DIFF
--- a/src/core/ChannelIndex.cpp
+++ b/src/core/ChannelIndex.cpp
@@ -195,7 +195,7 @@ std::istream &operator>>(std::istream &is, ChannelIndex &dex)
             return is;
 
         if ( DeviceManager::Register().contains(parts.at(1)) )
-            dex.daqClass = parts.at(2);
+            dex.daqClass = parts.at(1);
         else
             return is;
 


### PR DESCRIPTION
Bad things that happen when testing is only done manually: The most obvious bugs stick around for ever so long.