### PR TITLE
More fixes to v2017

### DIFF
--- a/src/core/DCThread.cpp
+++ b/src/core/DCThread.cpp
@@ -440,16 +440,6 @@ void DCThread::run()
          }
          //--------------- Data saving end ---------------------//
 
-         // Updated display
-         if ( graph ) {
-             if ( t - lastWrite > graphDt ) {
-                 lastWrite = t;
-                 i = 0;
-                 for ( double *val : graphVar )
-                    graph->q[i++]->push(GraphDlg::DataPoint {t, *val});
-             }
-         }
-
          // Rate update
          ++rateCounter;
          if ( t - lastRateReport > 1 ) {
@@ -474,6 +464,16 @@ void DCThread::run()
              if ( b->check_limits(!limitWarningEmitted, w) ) {
                  emit CloseToLimit(w.what, w.chan_label, w.loLim, w.hiLim, w.value);
                  limitWarningEmitted = true;
+             }
+         }
+
+         // Updated display
+         if ( graph ) {
+             if ( t - lastWrite > graphDt ) {
+                 lastWrite = t;
+                 i = 0;
+                 for ( double *val : graphVar )
+                    graph->q[i++]->push(GraphDlg::DataPoint {t, *val});
              }
          }
 

--- a/src/core/DCThread.cpp
+++ b/src/core/DCThread.cpp
@@ -705,6 +705,8 @@ bool DCThread::LoadScript(QString &fname)
                     .arg(dev->devID));
         }
         it = AP::find(rawname, &deprecChannels);
+        if ( it )
+            message(QString("Note: %1 (%2) -> %3").arg(rawname, it->name(), it->canonicalName()));
     }
     if ( it ) {
         scriptq.append(qMakePair(et, it->readLater(rawname, is, &success)));

--- a/src/core/DCThread.cpp
+++ b/src/core/DCThread.cpp
@@ -471,8 +471,10 @@ void DCThread::run()
          // Check channel limits
          DAQ::ChannelLimitWarning w;
          for ( auto &b : Devices.active() ) {
-             if ( b->check_limits(!limitWarningEmitted, w) )
+             if ( b->check_limits(!limitWarningEmitted, w) ) {
                  emit CloseToLimit(w.what, w.chan_label, w.loLim, w.hiLim, w.value);
+                 limitWarningEmitted = true;
+             }
          }
 
      // --- Calculate end --- //

--- a/src/include/AP.h
+++ b/src/include/AP.h
@@ -95,6 +95,7 @@ public:
     }
 
     inline QString const& name() { return _name; }
+    virtual QString const& canonicalName() { return name(); }
 
     static inline std::vector<std::unique_ptr<AP>> &params() { static std::vector<std::unique_ptr<AP>> p; return p; }
 
@@ -337,6 +338,8 @@ public:
     }
 
     virtual void write(std::ostream &) {}
+
+    virtual QString const& canonicalName() { return target->name(); }
 
 private:
     AP *target;


### PR DESCRIPTION
Attila noticed that scripted channel biases (using old-style script variables) don't work, so I've provided a deprecation fix and log note for that... and found, during investigating, a couple of other issues (GUI freezing on continued limit overstepping, and graph showing unlimited output instead of what is actually pushed to the DAQs.
I'll tag a new release v2017.0.1 with these fixes once they're merged.